### PR TITLE
 Checks the extension of allowed media files without case checking

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -201,7 +201,7 @@ public sealed class AdminController : Controller
                 {
                     var extension = Path.GetExtension(file.FileName);
 
-                    if (!allowedExtensions.Contains(extension))
+                    if (!allowedExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
                     {
                         result.Add(new
                         {


### PR DESCRIPTION
Adding a media file with an uppercase extension, when I save the content I get this error: "This file extension is not allowed"

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->